### PR TITLE
Add GitHub Action to run Zoom to Drive

### DIFF
--- a/.github/workflows/run-zoom-to-drive.yml
+++ b/.github/workflows/run-zoom-to-drive.yml
@@ -1,0 +1,38 @@
+name: Run Zoom to Drive
+
+on:
+  schedule:
+    - cron: '10 0 * * 5' # Runs every Friday at 11:10am Melbourne time
+  workflow_dispatch:
+
+jobs:
+  run-zoom-to-drive:
+    runs-on: ubuntu-latest
+
+    env:
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
+      ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
+      ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
+      GOOGLE_SHARED_DRIVE_ID: ${{ secrets.GOOGLE_SHARED_DRIVE_ID }}
+      GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEBUG: 'false'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r zoom_manager/requirements.txt
+
+    - name: Run Zoom to Drive
+      run: |
+        python zoom_manager/src/main.py --name "${{ secrets.MEETING_NAME }}" --email "${{ secrets.USER_EMAIL }}" --days ${{ secrets.DAYS }}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install -r requirements.txt
       - Zoom OAuth 2.0 credentials (from Zoom Marketplace)
       - Google Drive API credentials
       - Slack webhook URL (optional)
-    - Place your Google API credentials file in the `credentials` directory
+    - Store your Google Cloud service account key as a GitHub Secret
 
 ## 📁 Project Structure
 
@@ -59,11 +59,7 @@ pip install -r requirements.txt
 mkdir -p logs downloads credentials
 ```
 
-2. Place your Google API credentials:
-   - Move your downloaded credentials JSON to `credentials/credentials.json`
-   - Ensure credentials file is in .gitignore
-
-3. Configure `.env` file:
+2. Configure `.env` file:
    - Never commit this file (it should be in .gitignore)
    - Fill in your actual credentials:
 ```bash
@@ -72,6 +68,7 @@ ZOOM_CLIENT_SECRET=your_actual_client_secret
 ZOOM_ACCOUNT_ID=your_actual_account_id
 GOOGLE_SHARED_DRIVE_ID=your_drive_id
 GOOGLE_DRIVE_FOLDER_ID=your_folder_id
+GOOGLE_SERVICE_ACCOUNT_KEY=your_service_account_key
 SLACK_WEBHOOK_URL=your_webhook_url  # Optional
 DEBUG=false
 ```
@@ -120,7 +117,7 @@ The application includes comprehensive error handling for:
 
 ### Error: "Authentication failed"
 - Ensure that your Zoom OAuth 2.0 and Google Drive API credentials are correct.
-- Verify that the `credentials.json` file is placed in the `zoom_manager/credentials` directory.
+- Verify that the `GOOGLE_SERVICE_ACCOUNT_KEY` is set correctly in the `.env` file.
 
 ### Error: "Failed to get access token"
 - Check your Zoom OAuth 2.0 credentials in the `.env` file.
@@ -167,3 +164,90 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
+
+## 🛠️ GitHub Actions
+
+To automate running the application, you can set up a GitHub Action workflow. Follow these steps:
+
+1. Create a new file in your repository at `.github/workflows/run-zoom-to-drive.yml`.
+
+2. Add the following content to the file:
+
+```yaml
+name: Run Zoom to Drive
+
+on:
+  schedule:
+    - cron: '10 0 * * 5' # Runs every Friday at 11:10am Melbourne time
+  workflow_dispatch:
+
+jobs:
+  run-zoom-to-drive:
+    runs-on: ubuntu-latest
+
+    env:
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
+      ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
+      ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
+      GOOGLE_SHARED_DRIVE_ID: ${{ secrets.GOOGLE_SHARED_DRIVE_ID }}
+      GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEBUG: 'false'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r zoom_manager/requirements.txt
+
+    - name: Run Zoom to Drive
+      run: |
+        python zoom_manager/src/main.py --name "${{ secrets.MEETING_NAME }}" --email "${{ secrets.USER_EMAIL }}" --days ${{ secrets.DAYS }}
+```
+
+3. Add your secrets to the GitHub repository:
+   - Go to the repository settings.
+   - Click on "Secrets and variables" > "Actions".
+   - Add the following secrets:
+     - `ZOOM_CLIENT_ID`
+     - `ZOOM_CLIENT_SECRET`
+     - `ZOOM_ACCOUNT_ID`
+     - `GOOGLE_SHARED_DRIVE_ID`
+     - `GOOGLE_DRIVE_FOLDER_ID`
+     - `GOOGLE_SERVICE_ACCOUNT_KEY`
+     - `SLACK_WEBHOOK_URL` (optional)
+
+4. The GitHub Action will now run the script on a schedule (e.g., daily at midnight) or manually via the "Run workflow" button in the Actions tab.
+
+## 🌐 Obtaining the GOOGLE_SERVICE_ACCOUNT_KEY
+
+To obtain the `GOOGLE_SERVICE_ACCOUNT_KEY`, follow these steps:
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a new project or select an existing project.
+3. Enable the Google Drive API for your project.
+4. Create a service account:
+   - Go to the "IAM & Admin" > "Service Accounts" page.
+   - Click "Create Service Account".
+   - Fill in the required details and click "Create".
+5. Assign the necessary roles to the service account:
+   - Click on the service account you created.
+   - Go to the "Permissions" tab.
+   - Click "Add Member" and add the roles required for accessing Google Drive (e.g., "Drive API Admin").
+6. Create a key for the service account:
+   - Go to the "Keys" tab.
+   - Click "Add Key" > "Create New Key".
+   - Select "JSON" and click "Create".
+   - A JSON file containing the service account key will be downloaded to your computer.
+7. Open the JSON file and copy its contents.
+8. Store the contents of the JSON file as a GitHub Secret named `GOOGLE_SERVICE_ACCOUNT_KEY`.
+

--- a/zoom_manager/.github/workflows/run-zoom-to-drive.yml
+++ b/zoom_manager/.github/workflows/run-zoom-to-drive.yml
@@ -1,0 +1,50 @@
+name: Run Zoom to Drive
+
+on:
+  schedule:
+    - cron: '10 0 * * 5' # Runs every Friday at 11:10am Melbourne time
+  workflow_dispatch:
+
+jobs:
+  run-zoom-to-drive:
+    runs-on: ubuntu-latest
+
+    env:
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
+      ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
+      ZOOM_ACCOUNT_ID: ${{ secrets.ZOOM_ACCOUNT_ID }}
+      GOOGLE_SHARED_DRIVE_ID: ${{ secrets.GOOGLE_SHARED_DRIVE_ID }}
+      GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+      GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      DEBUG: 'false'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r zoom_manager/requirements.txt
+
+    - name: Validate Melbourne Time
+      run: |
+        python -c "
+import pytz
+from datetime import datetime
+
+melbourne_tz = pytz.timezone('Australia/Melbourne')
+current_time = datetime.now(melbourne_tz)
+if current_time.strftime('%H:%M') != '11:10':
+    raise SystemExit('Not the scheduled time to run the script.')
+"
+
+    - name: Run Zoom to Drive
+      run: |
+        python zoom_manager/src/main.py --name "${{ secrets.MEETING_NAME }}" --email "${{ secrets.USER_EMAIL }}" --days ${{ secrets.DAYS }}

--- a/zoom_manager/config/settings.py
+++ b/zoom_manager/config/settings.py
@@ -33,9 +33,9 @@ ZOOM_API_BASE_URL = "https://api.zoom.us/v2"
 
 # Google Drive Configuration
 GOOGLE_CREDENTIALS_FILE = CREDENTIALS_DIR / "credentials.json"
-GOOGLE_TOKEN_FILE = CREDENTIALS_DIR / "token.pickle"
 GOOGLE_SHARED_DRIVE_ID = os.getenv("GOOGLE_SHARED_DRIVE_ID") or None  # Allow CLI override
 GOOGLE_TARGET_FOLDER_ID = os.getenv("GOOGLE_DRIVE_FOLDER_ID") or None  # Allow CLI override
+GOOGLE_SERVICE_ACCOUNT_KEY = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY")
 
 # Slack Configuration
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")

--- a/zoom_manager/env_example
+++ b/zoom_manager/env_example
@@ -6,9 +6,9 @@ ZOOM_CLIENT_SECRET=your_zoom_client_secret
 ZOOM_ACCOUNT_ID=your_zoom_account_id
 
 #Google Drive API Credentials
-GOOGLE_CREDENTIALS_FILE=credentials.json
 GOOGLE_SHARED_DRIVE_ID=your_google_shared_drive_id
 GOOGLE_DRIVE_FOLDER_ID=your_google_drive_folder_id
+GOOGLE_SERVICE_ACCOUNT_KEY=your_google_service_account_key
 
 #Slack Webhook URL
 SLACK_WEBHOOK_URL=your_slack_webhook_url


### PR DESCRIPTION
Add GitHub Action workflow to run the application outside the terminal.

* **GitHub Action Workflow**:
  - Add `zoom_manager/.github/workflows/run-zoom-to-drive.yml` to automate running the application with environment variables provided as GitHub Secrets.
  - Schedule the action to run every Friday at 11:10am Melbourne time.
  - Include steps to validate the current time in Melbourne before running the script.

* **Environment Configuration**:
  - Modify `zoom_manager/env_example` to remove `GOOGLE_CREDENTIALS_FILE` and add `GOOGLE_SERVICE_ACCOUNT_KEY`.

* **Settings Configuration**:
  - Update `zoom_manager/config/settings.py` to remove `GOOGLE_TOKEN_FILE` and add `GOOGLE_SERVICE_ACCOUNT_KEY`.

* **Google Drive Client**:
  - Update `zoom_manager/src/google_drive_client.py` to remove code that loads and saves the token from/to `token.pickle`.
  - Update authentication to use the service account key from the environment variable.

* **Documentation**:
  - Update `README.md` to include instructions for setting up and using the GitHub Action.
  - Remove references to `credentials.json` and `token.pickle`.
  - Add instructions for obtaining the `GOOGLE_SERVICE_ACCOUNT_KEY`.

